### PR TITLE
Update axis autoscale

### DIFF
--- a/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/dataprovider/Sample.java
+++ b/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/dataprovider/Sample.java
@@ -14,12 +14,7 @@ package org.eclipse.nebula.visualization.xygraph.dataprovider;
  *  represents a number of 5 that could also be anywhere in 4 .. 7.
  *  The errors are not percentages.
  *  The 'negative' error is actually a positive number.
- *  <p>
- *  Note:
- *  Only the x/y value is used in equals()!
- *  Error ranges and info texts are ignored when determining equality
- *  with another Sample.
- *  
+ *
  *  @author Xihui Chen
  *  @author Kay Kasemir Comments, made immutable
  */
@@ -111,15 +106,6 @@ public class Sample implements ISample {
 	public String getInfo() {
 		return info;
 	}
-	
-	
-
-//    @Override
-//    public boolean equals(final Object obj) {
-//    	if(obj instanceof Sample)
-//    		return  (((Sample)obj).xValue == xValue && ((Sample)obj).yValue == yValue);
-//    	return false;
-//    }
 
     @Override
 	public int hashCode() {

--- a/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Axis.java
+++ b/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Axis.java
@@ -50,9 +50,6 @@ public class Axis extends LinearScale{
     /** The auto zoom interval in ms.*/
     final static int ZOOM_SPEED = 200;
 
-//	private static final Color GRAY_COLOR = XYGraphMediaFactory.getInstance().getColor(
-//			XYGraphMediaFactory.COLOR_GRAY);
-
     private String title;
 
     final private List<Trace> traceList = new ArrayList<Trace>();

--- a/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Axis.java
+++ b/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Axis.java
@@ -310,12 +310,16 @@ public class Axis extends LinearScale{
 	 */
 	public boolean performAutoScale(final boolean force) {
 	    // Anything to do? Autoscale not enabled nor forced?
-		if (traceList.size() <= 0  ||  !(force || autoScale))
+		if (traceList.size() <= 0  ||  !(force || autoScale)) {
 		    return false;
+		}
 
-	    // Get range of data in all traces
-        Range range = getTraceDataRange();
-        if (range == null) return false;
+		// Get range of data in all traces
+		Range range = getTraceDataRange();
+		if (range == null) {
+			return false;
+		}
+
 		double dataMin = range.getLower();
 		double dataMax = range.getUpper();
 
@@ -323,37 +327,47 @@ public class Axis extends LinearScale{
 		double axisMax = getRange().getUpper();
 		double axisMin = getRange().getLower();
 
+		if (rangeIsUnchanged(dataMin, dataMax, axisMin, axisMax) ||
+		        Double.isInfinite(dataMin) || Double.isInfinite(dataMax) ||
+		        Double.isNaN(dataMin) || Double.isNaN(dataMax)) {
+		    return false;
+		}
+
 		// The threshold is 'shared' between upper and lower range, times by 0.5
 		final double thr = (axisMax - axisMin) * 0.5 * autoScaleThreshold;
 
+		boolean lowerChanged = (dataMin - axisMin) < 0 || (dataMin - axisMin) >= thr;
+		boolean upperChanged = (axisMax - dataMax) < 0 || (axisMax - dataMax) >= thr;
 		// If both the changes are lower than threshold, return
-		if(((dataMin - axisMin)>=0 && (dataMin - axisMin)<thr)
-				&& ((axisMax - dataMax)>=0 && (axisMax - dataMax)<thr)){
+		if (!lowerChanged && !upperChanged) {
 			return false;
 		}
 
-		// Only increase the range of the lower axis
-		if((axisMin - dataMin) > 0 && (axisMax - dataMax)>=0) {
-			range = new Range(dataMin, axisMax);
-		}
+		// Calculate updated range
+		double newMax = upperChanged ? dataMax : axisMax;
+		double newMin = lowerChanged ? dataMin : axisMin;
+		range = new Range(newMin, newMax);
 
-		// Only increase the range of the upper axis
-		if((dataMax - axisMax) > 0 && (dataMin - axisMin)>=0) {
-			range = new Range(axisMin, dataMax);
-		}
-
-		if((Double.doubleToLongBits(dataMin) == Double.doubleToLongBits(axisMin)
-				&& Double.doubleToLongBits(dataMax) == Double.doubleToLongBits(axisMax)) ||
-				Double.isInfinite(dataMin) || Double.isInfinite(dataMax) ||
-				Double.isNaN(dataMin) || Double.isNaN(dataMax))
-			return false;
-
-        // by-pass overridden method as it sets ticks to false
-        super.setRange(range.getLower(), range.getUpper());
+		// by-pass overridden method as it sets ticks to false
+		super.setRange(range.getLower(), range.getUpper());
 		fireAxisRangeChanged(getRange(), range);
 		setTicksAtEnds(!axisAutoscaleTight);
 		repaint();
 		return true;
+	}
+
+	/**
+	 * Determines if upper or lower data has changed from current axis limits
+	 *
+	 * @param dataMin - min of data in buffer
+	 * @param dataMax - max of data in buffer
+	 * @param axisMin - current axis min
+	 * @param axisMax - current axis max
+	 * @return TRUE if data and axis max and min values are equal
+	 */
+	private boolean rangeIsUnchanged(double dataMin, double dataMax, double axisMin, double axisMax) {
+		return Double.doubleToLongBits(dataMin) == Double.doubleToLongBits(axisMin)
+			&& Double.doubleToLongBits(dataMax) == Double.doubleToLongBits(axisMax);
 	}
 
 	/**Add a trace to the axis.

--- a/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Trace.java
+++ b/PureJava/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Trace.java
@@ -1409,23 +1409,27 @@ public class Trace extends Figure implements IDataProviderListener,
          * could be drawn between inside data and outside data. <b>This method only
          * works for chronological data, which means the data is naturally sorted on
          * xAxis.</b>
-         * 
-         * @return the Range of the index.
+         *
+         * @return the Range of the index or NULL if no sensible range is found.
          */
         protected Range getIndexRangeOnXAxis() {
                 Range axisRange = xAxis.getRange();
                 if (traceDataProvider.getSize() <= 0)
                         return null;
+
+                // Sort upper/lower limits to ensure max > min
                 double min = axisRange.getLower() > axisRange.getUpper() ? axisRange
                                 .getUpper() : axisRange.getLower();
                 double max = axisRange.getUpper() > axisRange.getLower() ? axisRange
                                 .getUpper() : axisRange.getLower();
 
+               // Data lies entirely outside the axis range
                 if (min > traceDataProvider.getSample(traceDataProvider.getSize() - 1)
                                 .getXValue()
                                 || max < traceDataProvider.getSample(0).getXValue())
                         return null;
 
+                // find indices of data inside the range; start with all data
                 int lowIndex = 0;
                 int highIndex = traceDataProvider.getSize() - 1;
                 if (min > traceDataProvider.getSample(0).getXValue())


### PR DESCRIPTION
Update the axis autoscale scale algorithm to update both max and min on one pass.
This prevents the axis minimum being 'locked' at zero.